### PR TITLE
Fix Plex refresh race condition and webhook event filtering

### DIFF
--- a/bazarr/api/webhooks/plex.py
+++ b/bazarr/api/webhooks/plex.py
@@ -52,7 +52,7 @@ class WebHooksPlex(Resource):
             
             event = parsed_json_webhook['event']
             
-            if event not in ['media.play']:
+            if event not in ['media.play', 'playback.started']:
                 logger.debug('PLEX WEBHOOK: Ignoring unhandled event "%s"', event)
                 return 'Unhandled event', 204
             

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -17,6 +17,7 @@ from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream, show_progress, hide_progress
 from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path
+from plex.operations import plex_refresh_item
 
 gc.enable()
 
@@ -141,6 +142,30 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
             if movie:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")
                 list_missing_subtitles_movies(no=movie.radarrId)
+                
+                # If external subtitles were found during indexing, refresh Plex metadata
+                # This fixes the race condition where subtitles exist but Plex doesn't see them
+                # Only refresh if subtitles list has changed to avoid excessive IO
+                if actual_subtitles and settings.general.use_plex and settings.plex.update_movie_library:
+                    # Get current stored subtitles to compare with new findings
+                    current_movie_data = database.execute(
+                        select(TableMovies.imdbId, TableMovies.subtitles)
+                        .where(TableMovies.radarrId == movie.radarrId)
+                    ).first()
+                    
+                    if current_movie_data and current_movie_data.imdbId:
+                        # Parse existing subtitles from database
+                        try:
+                            existing_subtitles = ast.literal_eval(current_movie_data.subtitles) if current_movie_data.subtitles else []
+                        except (ValueError, SyntaxError):
+                            existing_subtitles = []
+                        
+                        # Only refresh Plex if subtitle list has changed (new subtitles detected)
+                        if actual_subtitles != existing_subtitles:
+                            logging.info(f"BAZARR detected subtitle changes for movie IMDB {current_movie_data.imdbId}, triggering Plex refresh")
+                            plex_refresh_item(current_movie_data.imdbId, is_movie=True)
+                        else:
+                            logging.debug(f"BAZARR no subtitle changes detected for movie IMDB {current_movie_data.imdbId}, skipping Plex refresh")
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")
     else:

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -17,6 +17,7 @@ from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream, show_progress, hide_progress
 from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path
+from plex.operations import plex_refresh_item
 
 gc.enable()
 
@@ -140,6 +141,33 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
             if episode:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")
                 list_missing_subtitles(epno=episode.sonarrEpisodeId)
+                
+                # If external subtitles were found during indexing, refresh Plex metadata
+                # This fixes the race condition where subtitles exist but Plex doesn't see them
+                # Only refresh if subtitles list has changed to avoid excessive IO
+                if actual_subtitles and settings.general.use_plex and settings.plex.update_series_library:
+                    # Get current stored subtitles to compare with new findings
+                    current_episode_data = database.execute(
+                        select(TableShows.imdbId, TableEpisodes.season, TableEpisodes.episode, TableEpisodes.subtitles)
+                        .select_from(TableEpisodes)
+                        .join(TableShows)
+                        .where(TableEpisodes.sonarrEpisodeId == episode.sonarrEpisodeId)
+                    ).first()
+                    
+                    if current_episode_data and current_episode_data.imdbId:
+                        # Parse existing subtitles from database
+                        try:
+                            existing_subtitles = ast.literal_eval(current_episode_data.subtitles) if current_episode_data.subtitles else []
+                        except (ValueError, SyntaxError):
+                            existing_subtitles = []
+                        
+                        # Only refresh Plex if subtitle list has changed (new subtitles detected)
+                        if actual_subtitles != existing_subtitles:
+                            logging.info(f"BAZARR detected subtitle changes for episode IMDB {current_episode_data.imdbId} S{current_episode_data.season:02d}E{current_episode_data.episode:02d}, triggering Plex refresh")
+                            plex_refresh_item(current_episode_data.imdbId, is_movie=False, 
+                                            season=current_episode_data.season, episode=current_episode_data.episode)
+                        else:
+                            logging.debug(f"BAZARR no subtitle changes detected for episode IMDB {current_episode_data.imdbId} S{current_episode_data.season:02d}E{current_episode_data.episode:02d}, skipping Plex refresh")
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")
     else:


### PR DESCRIPTION
- Fix webhook to accept both 'media.play' and 'playbook.started' events
  * Plex sends 'playbook.started' for shared users, 'media.play' for owners
  * Previously only 'media.play' was accepted, causing missed events

- Fix race condition where external subtitles don't trigger Plex refresh
  * Added intelligent Plex refresh logic to subtitle indexers
  * Only refreshes when subtitle list actually changes (prevents IO spam)
  * Covers both movies and TV series
  * Respects existing Plex integration settings

This fixes issues where:
1. Subtitles downloaded outside Bazarr remain invisible in Plex
2. Webhook events from shared users are ignored
3. Manual subtitle additions don't refresh Plex metadata

Addresses: Nobody 2 subtitle visibility issue and webhook event filtering